### PR TITLE
exfat_{core,super}.c: fix build on 5.0-rc1, MS_* -> SB_*

### DIFF
--- a/exfat_core.c
+++ b/exfat_core.c
@@ -1757,8 +1757,12 @@ void fs_error(struct super_block *sb)
 
 	if (opts->errors == EXFAT_ERRORS_PANIC)
 		panic("[EXFAT] Filesystem panic from previous error\n");
-	else if ((opts->errors == EXFAT_ERRORS_RO) && !(sb->s_flags & MS_RDONLY)) {
+	else if ((opts->errors == EXFAT_ERRORS_RO) && !EXFAT_IS_SB_RDONLY(sb)) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
 		sb->s_flags |= MS_RDONLY;
+#else
+		sb->s_flags |= SB_RDONLY;
+#endif
 		printk(KERN_ERR "[EXFAT] Filesystem has been set read-only\n");
 	}
 }

--- a/exfat_core.h
+++ b/exfat_core.h
@@ -45,6 +45,12 @@
 #include "exfat_api.h"
 #include "exfat_cache.h"
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
+#define EXFAT_IS_SB_RDONLY(sb) ((sb)->s_flags & MS_RDONLY)
+#else
+#define EXFAT_IS_SB_RDONLY(sb) ((sb)->s_flags & SB_RDONLY)
+#endif
+
 #ifdef CONFIG_EXFAT_KERNEL_DEBUG
   /* For Debugging Purpose */
 	/* IOCTL code 'f' used by

--- a/exfat_super.c
+++ b/exfat_super.c
@@ -2086,7 +2086,7 @@ static void exfat_write_super(struct super_block *sb)
 
 	__set_sb_clean(sb);
 
-	if (!(sb->s_flags & MS_RDONLY))
+	if (!EXFAT_IS_SB_RDONLY(sb))
 		FsSyncVol(sb, 1);
 
 	__unlock_super(sb);
@@ -2142,7 +2142,12 @@ static int exfat_statfs(struct dentry *dentry, struct kstatfs *buf)
 
 static int exfat_remount(struct super_block *sb, int *flags, char *data)
 {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
 	*flags |= MS_NODIRATIME;
+#else
+	*flags |= SB_NODIRATIME;
+#endif
+
 	return 0;
 }
 
@@ -2495,7 +2500,11 @@ static int exfat_fill_super(struct super_block *sb, void *data, int silent)
 	mutex_init(&sbi->s_lock);
 #endif
 	sb->s_fs_info = sbi;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
 	sb->s_flags |= MS_NODIRATIME;
+#else
+	sb->s_flags |= SB_NODIRATIME;
+#endif
 	sb->s_magic = EXFAT_SUPER_MAGIC;
 	sb->s_op = &exfat_sops;
 	sb->s_export_op = &exfat_export_ops;


### PR DESCRIPTION
It seems that you are more active than dorimanx/exfat-nofuse, so I create my PR here :)

In torvalds/linux@e462ec50cb a new set of superblock flags was added to replace the original MS_* ones, and in torvalds/linux@e262e32d6b the MS_* flags are suppressed unless uapi/linux/mount.h is included. As is suggested, we should use the new API now.

I compiled it with Linux Kernel 5.0-rc1, and the build was successful. Though I haven't run the kernel yet, I think it just works.

---
```
The following changes since commit f93a47e6414d567a1e7f6ab7f34b015b20f9a050:

  Fix for 4.20 (2018-12-31 16:50:33 +0000)

are available in the Git repository at:

  https://github.com/lmy441900/exfat-nofuse 

for you to fetch changes up to 8b59e1f338fdd87f1d5a9db2a119a3745bb467d5:

  exfat_{core,super}.c: fix build on 5.0-rc1, MS_* -> SB_* (2019-01-10 23:13:35 +0800)

----------------------------------------------------------------
Junde Yhi (1):
      exfat_{core,super}.c: fix build on 5.0-rc1, MS_* -> SB_*

 exfat_core.c  |  6 +++++-
 exfat_core.h  |  6 ++++++
 exfat_super.c | 11 ++++++++++-
 3 files changed, 21 insertions(+), 2 deletions(-)
```